### PR TITLE
Update AutoRowHeightLayout.cs

### DIFF
--- a/Aga.Controls/Tree/AutoRowHeightLayout.cs
+++ b/Aga.Controls/Tree/AutoRowHeightLayout.cs
@@ -118,6 +118,9 @@ namespace Aga.Controls.Tree
 		public int GetRowAt(Point point)
 		{
 			int py = point.Y - _treeView.ActualColumnHeaderHeight;
+			if (py < 0)
+				return -1; 
+				
 			int y = 0;
 			for (int i = _treeView.FirstVisibleRow; i < _treeView.RowCount; i++)
 			{


### PR DESCRIPTION
Avoid wasted enumeration of all row heights if the selection is on the header column for which the function is expected to return -1 (at the end of the enumeration). When dealing with large sets (several thousands lines) - the response time for tree sorting through column click is unreasonable due to this enumeration.